### PR TITLE
Discretionary spendings support

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -97,6 +97,16 @@ documents:
     }
 
   - > 
+    query workersByAccount($account: String!) {
+      workers(where: {rewardAccount_eq: $account}) {
+        id
+        membership {
+          ...MemberFields
+        }
+      }
+    }
+
+  - > 
     query activeCouncilMembers {
       electedCouncils(where: {endedAtBlock_eq: null}) {
         councilMembers {

--- a/src/gql/pioneer.client.ts
+++ b/src/gql/pioneer.client.ts
@@ -56,6 +56,16 @@ export class RetryablePioneerClient {
   }
 
   @Retryable(globalRetryConfig)
+  async workersByAccount(account: string) {
+    this.logger.debug(`Fetching worker[${account}]...`);
+    const members = await this.pioneerApi.workersByAccount({account: account});
+    if(!members.workers || members.workers.length === 0) {
+      throw new Error();
+    }
+    return members;
+  }
+
+  @Retryable(globalRetryConfig)
   async applicationById(applicationId: string) {
     this.logger.debug(`Fetching application[${applicationId}]...`);
     const application = await this.pioneerApi.applicationById({applicationId: applicationId});

--- a/src/wg/budget.spending.handler.ts
+++ b/src/wg/budget.spending.handler.ts
@@ -1,0 +1,37 @@
+import { Balance } from "@joystream/types/common";
+import { Injectable} from "@nestjs/common";
+import { OnEvent } from "@nestjs/event-emitter";
+import { TextChannel } from "discord.js";
+import { EventWithBlock } from "src/types";
+import { BaseEventHandler } from "./base.event.handler";
+import { getDiscretionarySpendingEmbed, getDiscretionarySpendingToNonWorkerAddressEmbed } from "./embeds";
+
+@Injectable()
+export class BudgetSpendingHandler extends BaseEventHandler {
+
+  @OnEvent('*.BudgetSpending')
+  async handleBudgetSpendingEvent(payload: EventWithBlock) {
+    let { section, data } = payload.event.event;
+    if (!this.checkChannel(section)) {
+      return;
+    }
+    const payee = data[0].toString();
+    const spendingAmount = data[1] as Balance
+    try {
+      const payeeWorker = await this.queryNodeClient.workersByAccount(payee);
+      this.channels[section].forEach((ch: TextChannel) =>
+        ch.send({
+          embeds: [
+            getDiscretionarySpendingEmbed(spendingAmount, payeeWorker, payload.block, payload.event),
+          ],
+        }));
+    } catch(e) {
+      this.channels[section].forEach((ch: TextChannel) =>
+        ch.send({
+          embeds: [
+            getDiscretionarySpendingToNonWorkerAddressEmbed(spendingAmount, payee, payload.block, payload.event),
+          ],
+        }));      
+    }
+  }
+}

--- a/src/wg/embeds.ts
+++ b/src/wg/embeds.ts
@@ -4,7 +4,7 @@ import { EventRecord } from '@polkadot/types/interfaces';
 import Discord from 'discord.js';
 import { OpeningId, ApplicationId } from "@joystream/types/working-group";
 import { Balance } from '@joystream/types/common';
-import { OpeningByIdQuery, WorkerByIdQuery, ApplicationByIdQuery, MemberByIdQuery } from '../qntypes';
+import { OpeningByIdQuery, WorkerByIdQuery, ApplicationByIdQuery, MemberByIdQuery, WorkersByAccountQuery } from '../qntypes';
 
 
 export const getBudgetSetEmbed = (balanceSet: number, blockNumber: number, event: EventRecord): Discord.MessageEmbed => {
@@ -65,6 +65,28 @@ export const getWorkerRewardAmountUpdatedEmbed = (reward: Balance, member: Worke
       { name: 'Salary', value: formatBalance(reward.toString(), { withUnit: 'tJOY' }), inline: true }
     ), blockNumber, event);
 }
+
+export const getDiscretionarySpendingEmbed = (spending: Balance, recipient: WorkersByAccountQuery,
+  blockNumber: number, event: EventRecord): Discord.MessageEmbed => {
+
+  return addCommonProperties(new Discord.MessageEmbed()
+    .setTitle(`💰💰💰 User ${recipient.workers[0].membership.handle} was paid via discretionary budget spending`)
+    .addFields(
+      { name: 'Amount paid', value: formatBalance(spending.toString(), { withUnit: 'tJOY' }), inline: true }
+    ), blockNumber, event);
+}
+
+export const getDiscretionarySpendingToNonWorkerAddressEmbed = (spending: Balance, recipientAddress: string,
+  blockNumber: number, event: EventRecord): Discord.MessageEmbed => {
+
+  return addCommonProperties(new Discord.MessageEmbed()
+    .setTitle(`💰💰💰 Discretionary budget spending was made`)
+    .addFields(
+      { name: 'Amount paid', value: formatBalance(spending.toString(), { withUnit: 'tJOY' }), inline: true },
+      { name: 'Recipient', value: recipientAddress, inline: true }
+    ), blockNumber, event);
+}
+
 
 export const getWorkerRewardedEmbed = (reward: Balance, member: WorkerByIdQuery, missed: boolean,
   blockNumber: number, event: EventRecord): Discord.MessageEmbed => {

--- a/src/wg/wg.module.ts
+++ b/src/wg/wg.module.ts
@@ -15,6 +15,7 @@ import { StakeHandler } from './stake.handler';
 import { TerminationHandler } from './termination.handler';
 import { WorkerExitedHandler } from './worker.exited.handler';
 import { WorkingGroupService } from './wg.service';
+import { BudgetSpendingHandler } from './budget.spending.handler';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { WorkingGroupService } from './wg.service';
   providers: [
     BudgetSetHandler,
     BudgetUpdatedHandler,
+    BudgetSpendingHandler,
     ApplicationCreatedHandler,
     ApplicationWithdrawnHandler, 
     OpeningAddedOrCancelledHandler,


### PR DESCRIPTION
Added support for `workingGroupXYZ.BudgetSpending` event (discretionary spendings). 

The notification looks like this: 
1. Case of a random wallet 
<img width="555" alt="Screenshot 2022-06-26 at 21 16 47" src="https://user-images.githubusercontent.com/7863785/175828350-a8cee2ee-4f38-43f7-ab8f-40cbd92c0160.png">
2. Case of discretionary payment to a worker
<img width="553" alt="Screenshot 2022-06-26 at 21 19 19" src="https://user-images.githubusercontent.com/7863785/175828450-4da72c34-2cb5-4519-a794-f84abd3692a5.png">
